### PR TITLE
fix: smtp quit error

### DIFF
--- a/heimdallr/channel/email.py
+++ b/heimdallr/channel/email.py
@@ -45,6 +45,7 @@ class Email(Channel):
         self.sender: str = "Heimdallr"
         self.to: str = ""
         self.starttls: bool = False
+        self.smtp_object: smtplib.SMTP
         self._build_channel()
 
     def _build_channel(self):


### PR DESCRIPTION
fixed a error where sending email through smtp fails due to the typing of the variable `smtp_object`